### PR TITLE
Fixed aliens being able to place a facehugger onto an already-infected human. Fixes #57

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -190,6 +190,7 @@ var/const/MAX_ACTIVE_TIME = 250
 
 /obj/item/clothing/mask/facehugger/proc/Attach(mob/living/M as mob)
 	if( (!iscorgi(M) && !iscarbon(M)) || isalien(M) || M.status_flags & XENO_HOST)
+		visible_message("\red An alien tries to place a Facehugger on [M] but it refuses sloppy seconds!")
 		return
 	if(attached)
 		return


### PR DESCRIPTION
This seems to fix both when an alien tries to slap a hugger onto an already-infected human OR if the alien tries to equip the hugger onto the human by click+dragging the human's body to open their inventory.

Two things:
1. I had to change the proc name (line 191) from "M" to "mob/living/M" in order to inherit the ability to use "status_flags" in the next line, otherwise it won't compile. Is this optimum? I may have broken something doing it this way - I don't know.
2. I'd like to add some kind of user feedback so that Alien player knows that the reason the hugger isn't being attatched is because the human is already infected. This way they don't keep picking up the hugger and clicking on the human and wonder why it's not working.
