### PR TITLE
Fix to make the Facehugger spam check more specific to prevent the visible_message from displaying when used on other things

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -189,7 +189,9 @@ var/const/MAX_ACTIVE_TIME = 250
 		Attach(hit_atom)
 
 /obj/item/clothing/mask/facehugger/proc/Attach(mob/living/M as mob)
-	if( (!iscorgi(M) && !iscarbon(M)) || isalien(M) || M.status_flags & XENO_HOST)
+	if( (!iscorgi(M) && !iscarbon(M)) || isalien(M))
+		return
+	if(iscarbon(M) && M.status_flags & XENO_HOST)
 		visible_message("\red An alien tries to place a Facehugger on [M] but it refuses sloppy seconds!")
 		return
 	if(attached)


### PR DESCRIPTION
Fixes this:

![this](http://i.imgur.com/Bj2fZ5c.png)

Tested and working. Might need some minor tweaking in the future.
