### PR TITLE
Barrier fix

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -270,3 +270,14 @@ for reference:
 		explosion(src.loc,-1,-1,0)
 		if(src)
 			del(src)
+
+//ALIUM SLASHING CODE SUPER MEGA TEMP GHETTO FIX OF GHETTONESS or maybe permanentness...
+
+/obj/structure/barricade/wooden/attack_alien(mob/user)
+	visible_message("<span class='danger'>[user] slices [src] apart!</span>")
+	if(health < 1)
+		new /obj/item/stack/sheet/wood(get_turf(src))
+		new /obj/item/stack/sheet/wood(get_turf(src))
+		new /obj/item/stack/sheet/wood(get_turf(src))
+		del(src)
+	health -= 20


### PR DESCRIPTION
Apparently, wooden barriers were immune to Xeno Charms, but it's fixed
now.
