### PR TITLE
Commented out unneeded code that causes warnings during compile

### DIFF
--- a/code/game/machinery/computer/marine_card.dm
+++ b/code/game/machinery/computer/marine_card.dm
@@ -264,8 +264,8 @@
 					for(var/jobtype in typesof(/datum/job))
 						var/datum/job/J = new jobtype
 						if(ckey(J.title) == ckey(t1))
-							var/datum/job/jobdatum
-							jobdatum = J
+							//var/datum/job/jobdatum
+							//jobdatum = J
 							break
 					//if(!jobdatum)
 					//	usr << "\red No log exists for this job."

--- a/code/modules/mob/living/carbon/human/update_icons2.dm
+++ b/code/modules/mob/living/carbon/human/update_icons2.dm
@@ -428,14 +428,14 @@ proc/get_damage_icon_part(damage_state, body_part)
 	if(update_icons)   update_icons()
 
 /mob/living/carbon/human/update_mutations(var/update_icons=1)
-	var/fat
-	if(FAT in mutations)
-		fat = "fat"
+	//var/fat
+	//if(FAT in mutations)
+		//fat = "fat"
 
 	var/image/standing	= image("icon" = 'icons/effects/genetics.dmi')
 	var/add_image = 0
-	var/g = "m"
-	if(gender == FEMALE)	g = "f"
+	//var/g = "m"
+	//if(gender == FEMALE)	g = "f"
 	// DNA2 - Drawing underlays.
 	/*for(var/datum/dna/gene/gene in dna_genes)
 		if(!gene.block)


### PR DESCRIPTION
I might want a double-check on the marine_card.dm change. It doesn't seem to make any difference with regard to access, job assignment on an ID computer, etc, but I think if it did affect the access we would have noticed it a long time ago and fixed the warning.
